### PR TITLE
HasMeta: return parent::collection when meta is empty

### DIFF
--- a/src/HasMeta.php
+++ b/src/HasMeta.php
@@ -10,7 +10,7 @@ trait HasMeta
         $meta = self::meta();
 
         if (! count($meta)) {
-            parent::collection($resource);
+            return parent::collection($resource);
         }
 
         return parent::collection($resource)->additional([


### PR DESCRIPTION
The `collection()` method in the HasMeta class checks if there are any items returned by the `meta()` method by `count($meta)`. However, when that's the case, it only runs `parent::collection()` without returning it. In short: it does nothing... This PR adds a return so that `parent::collection()` will be returned without the extra (empty) meta.